### PR TITLE
Prevent exporting boost_sml as library as it is header only package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ catkin_package(
     roscpp
   INCLUDE_DIRS
     include
-  LIBRARIES
-    ${PROJECT_NAME}
   DEPENDS
     Boost
 )


### PR DESCRIPTION
Prevent exporting the package as library as a fix to depending packages not being able to find the headers.