### PR TITLE
Fix to compilation errors (sml_graph_demo.cpp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(boost_sml)
 
-# C++ 14
-add_compile_options(-std=c++14)
+# C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 # Warnings
 add_definitions(-W -Wall -Wextra


### PR DESCRIPTION
Fix to compilation errors when setting overriding `CMAKE_CXX_STANDARD` in catkin config. This fix helped locally. I think the root cause is that `-std=c++14` does not get correctly overridden when using `CMAKE_CXX_STANDARD` in catkin config and since I have been using C++17 there were files that wanted to use `sml.hpp` in C++14 mode and also in C++17 mode. 

@tylerjw @JafarAbdi do you have insight to this problem? Either way, please consider merging this quickly since it is basically risk free merge but appeared to help locally and possible would help with CI issues as well.