### PR TITLE
Fix undefined reference error

### DIFF
--- a/include/boost_sml/sml_transition_graph.h
+++ b/include/boost_sml/sml_transition_graph.h
@@ -27,7 +27,7 @@ class SmlTransitionGraph: public graph_t
 {
 public:
   using edge_t = std::pair<std::string, std::string>;
-  static constexpr vertex_descriptor NIL = std::numeric_limits<vertex_descriptor>::max();
+  static const vertex_descriptor NIL = std::numeric_limits<vertex_descriptor>::max();
 
   template <class SM>
   SmlTransitionGraph(const SM& sm)
@@ -70,7 +70,7 @@ public:
 
   std::vector<vertex_descriptor> find_predecessors(const vertex_descriptor& start_vertex)
   {
-    std::vector<vertex_descriptor> predecessors(boost::num_vertices(*this), std::numeric_limits<vertex_descriptor>::max());
+    std::vector<vertex_descriptor> predecessors(boost::num_vertices(*this), NIL);
     boost::breadth_first_search(
         *this, start_vertex,
         boost::visitor(boost::make_bfs_visitor(boost::record_predecessors(&predecessors[0], boost::on_tree_edge()))));

--- a/include/boost_sml/sml_transition_graph.h
+++ b/include/boost_sml/sml_transition_graph.h
@@ -27,7 +27,7 @@ class SmlTransitionGraph: public graph_t
 {
 public:
   using edge_t = std::pair<std::string, std::string>;
-  static const vertex_descriptor NIL = std::numeric_limits<vertex_descriptor>::max();
+  const vertex_descriptor NIL = std::numeric_limits<vertex_descriptor>::max();
 
   template <class SM>
   SmlTransitionGraph(const SM& sm)

--- a/include/boost_sml/sml_transition_graph.h
+++ b/include/boost_sml/sml_transition_graph.h
@@ -70,7 +70,7 @@ public:
 
   std::vector<vertex_descriptor> find_predecessors(const vertex_descriptor& start_vertex)
   {
-    std::vector<vertex_descriptor> predecessors(boost::num_vertices(*this),NIL  );
+    std::vector<vertex_descriptor> predecessors(boost::num_vertices(*this), std::numeric_limits<vertex_descriptor>::max());
     boost::breadth_first_search(
         *this, start_vertex,
         boost::visitor(boost::make_bfs_visitor(boost::record_predecessors(&predecessors[0], boost::on_tree_edge()))));


### PR DESCRIPTION
Fix undefined reference error when building in debug mode using g++ (Ubuntu 7.5.0-3ubuntu1~18.04). Probably a compiler bug but this seems to fix it.

@tylerjw found an explanation for the root cause: 
[https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char](https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char)