### PR TITLE
[ros-o] Upgrade C++ standard and cmake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(boost_sml)
 
-# C++14
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
 # Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(boost_sml)
 
 # Find catkin macros and libraries


### PR DESCRIPTION
- Remove enforcement of C++14 standard. Modern defaults are:
  - C++14 on Ubuntu 20.04 / gcc 9.4
  - C++17 on Ubuntu 22.04 / gcc 11.4

  Thus, C++14 is satisfied automatically on these systems.
  However, on Ubuntu 22.04, log4cxx requires C++17 (which is the default).
  Enforcing C++14 downgrades the standard, rendering log4cxx uncompilable.

- Update cmake minimum version according to [Noetic migration guide](http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning)

